### PR TITLE
PHP 7.2 - Deprecation of mcrypt compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
   ],
   "require": {
     "lib-curl": "*",
-    "ext-mcrypt": "*",
     "ext-dom": "*",
     "exacttarget/fuel-sdk-php": "v0.9"
   },

--- a/src/core/Encryption.php
+++ b/src/core/Encryption.php
@@ -15,6 +15,8 @@ class Encryption
     /** @var string The secret key to encrypt data. */
     private $_skey = "yourSecretKey";
 
+    const METHOD = 'aes-256-cbc';
+
     /**
      * @param string The secret key to encrypt data.
      */
@@ -34,10 +36,24 @@ class Encryption
         if (!$value) {
             return false;
         }
-        $iv_size = mcrypt_get_iv_size(MCRYPT_RIJNDAEL_256, MCRYPT_MODE_ECB);
+
+        $ivsize = openssl_cipher_iv_length(self::METHOD);
+        $iv = openssl_random_pseudo_bytes($ivsize);
+
+        $ciphertext = openssl_encrypt(
+            $value,
+            self::METHOD,
+            $this->_skey,
+            OPENSSL_RAW_DATA,
+            $iv
+        );
+
+        return trim($this->safe_b64encode($iv . $ciphertext));
+
+        /*$iv_size = mcrypt_get_iv_size(MCRYPT_RIJNDAEL_256, MCRYPT_MODE_ECB);
         $iv = mcrypt_create_iv($iv_size, MCRYPT_RAND);
         $crypttext = mcrypt_encrypt(MCRYPT_RIJNDAEL_256, $this->_skey, $value, MCRYPT_MODE_ECB, $iv);
-        return trim($this->safe_b64encode($crypttext));
+        return trim($this->safe_b64encode($crypttext)); */
     }
 
     /**
@@ -62,10 +78,26 @@ class Encryption
         if (!$value) {
             return false;
         }
-        $iv_size = mcrypt_get_iv_size(MCRYPT_RIJNDAEL_256, MCRYPT_MODE_ECB);
+
+        $value = $this->safe_b64decode($value);
+        $ivsize = openssl_cipher_iv_length(self::METHOD);
+        $iv = mb_substr($value, 0, $ivsize, '8bit');
+        $ciphertext = mb_substr($value, $ivsize, null, '8bit');
+
+        return trim(
+            openssl_decrypt(
+                $ciphertext,
+                self::METHOD,
+                $this->_skey,
+                OPENSSL_RAW_DATA,
+                $iv
+            )
+        );
+
+        /*$iv_size = mcrypt_get_iv_size(MCRYPT_RIJNDAEL_256, MCRYPT_MODE_ECB);
         $iv = mcrypt_create_iv($iv_size, MCRYPT_RAND);
         $decrypttext = mcrypt_decrypt(MCRYPT_RIJNDAEL_256, $this->_skey, $this->safe_b64decode($value), MCRYPT_MODE_ECB, $iv);
-        return trim($decrypttext);
+        return trim($decrypttext); */
     }
 
     /**


### PR DESCRIPTION
With the coming of PHP 7.2, the mcrypt extension is finally deprecated so this code no longer works.

Suggesting PR compatible with openssl that works from PHP 7.2 onwards.

(@germanjc  --te he dejado comentado el código anterior)